### PR TITLE
fix: v0.3.1 — VPS bugs + CLI twin wizard (414 tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pip install -e .[dev]
 lumen run
 ```
 
-## `lumen run` vs `lumen serve`
+## `lumen run` vs `lumen server`
 
 Lumen has two startup modes depending on where it runs.
 
@@ -82,7 +82,7 @@ Behavior:
 lumen run
 ```
 
-### `lumen serve`
+### `lumen server`
 
 Use this for:
 
@@ -100,13 +100,13 @@ Behavior:
 - future access to the dashboard requires login
 
 ```bash
-lumen serve --host 0.0.0.0 --port 3000
+lumen server --host 0.0.0.0 --port 3000
 ```
 
 Rule of thumb:
 
 - `lumen run` = I am running Lumen for myself on this machine
-- `lumen serve` = I am hosting Lumen so it can be accessed like a real installed web app
+- `lumen server` = I am hosting Lumen so it can be accessed like a real installed web app
 
 ### Run the test suite
 
@@ -143,10 +143,10 @@ lumen run
 
 Opens at `http://localhost:3000`. No auth required. Ideal for development and personal use.
 
-### VPS (`lumen serve`)
+### VPS (`lumen server`)
 
 ```bash
-lumen serve --host 0.0.0.0 --port 3000
+lumen server --host 0.0.0.0 --port 3000
 ```
 
 Shows a one-time setup token in the console. Access `http://your-ip:3000/setup`, enter the token, choose an owner PIN. After setup, the token is deleted and all access requires the PIN.
@@ -185,7 +185,7 @@ sudo certbot --nginx -d yourdomain.com
 
 ```bash
 lumen run [--port 3000] [--instance <name>] [--data-dir <path>]  # Start dashboard locally
-lumen serve [--host 0.0.0.0] [--port 3000] [--instance <name>]   # Start in server mode
+lumen server [--host 0.0.0.0] [--port 3000] [--instance <name>]   # Start in server mode
 lumen status                                                       # Show configuration and health
 lumen reload [--instance <name>]                                   # Reload runtime without restart
 lumen doctor                                                       # Diagnose and fix issues

--- a/lumen/__init__.py
+++ b/lumen/__init__.py
@@ -1,3 +1,3 @@
 """Lumen — Open-source AI agent engine."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/lumen/channels/web.py
+++ b/lumen/channels/web.py
@@ -94,9 +94,16 @@ _oauth_state_store: dict[str, dict] = {}
 _oauth_state_lock = threading.Lock()
 
 
-def configure(brain, locale: dict, config: dict, awareness=None):
-    """Configure the web channel (called by CLI when config exists)."""
-    global _brain, _locale, _config, _awareness
+def configure(brain, locale: dict, config: dict, awareness=None, *, lumen_dir: Path | None = None):
+    """Configure the web channel (called by CLI when config exists).
+    
+    Args:
+        lumen_dir: Instance-aware data directory. If None, uses default ~/.lumen/
+    """
+    global _brain, _locale, _config, _awareness, LUMEN_DIR, CONFIG_PATH
+    if lumen_dir is not None:
+        LUMEN_DIR = lumen_dir
+        CONFIG_PATH = lumen_dir / "config.yaml"
     _brain = brain
     _locale = locale
     _config = config

--- a/lumen/cli/main.py
+++ b/lumen/cli/main.py
@@ -147,15 +147,111 @@ def _main(ctx: typer.Context):
 # ── commands ─────────────────────────────────────────────────────────────────
 
 
+# ── CLI Twin Wizard ──────────────────────────────────────────────────────────
+
+WIZARD_PROVIDERS = {
+    "1": ("deepseek/deepseek-chat", "DeepSeek API key", True),
+    "2": ("openai/gpt-4o-mini", "OpenAI API key", True),
+    "3": ("anthropic/claude-sonnet-4-20250514", "Anthropic API key", True),
+    "4": ("ollama/llama3", None, False),
+    "5": ("openrouter/openai/gpt-oss-120b:free", None, False),
+}
+
+
+def _run_cli_wizard(*, lumen_dir: Path | None = None) -> dict:
+    """Run the onboarding wizard in the terminal.
+
+    Twin of the web wizard — same steps, terminal presentation.
+    Returns the config dict and saves config.yaml.
+
+    Steps:
+      1. Choose model provider
+      2. Enter API key (if needed)
+      3. Choose language
+      4. Save config.yaml
+    """
+    target_dir = lumen_dir or resolve_lumen_dir()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    config_path = target_dir / "config.yaml"
+
+    console.print()
+    console.print(Panel(
+        "[bold cyan]🔮 Bienvenido a Lumen[/bold cyan]\n\n"
+        "Vamos a configurar tu asistente.",
+        expand=False,
+        border_style=BRAND,
+    ))
+
+    # Step 1: Model provider
+    console.print("\n[bold]¿Qué modelo querés usar?[/bold]")
+    console.print("  1. DeepSeek (recomendado)")
+    console.print("  2. OpenAI GPT-4o-mini")
+    console.print("  3. Anthropic Claude")
+    console.print("  4. Ollama (local, sin API key)")
+    console.print("  5. OpenRouter (multi-model, tier gratuito)")
+
+    provider = Prompt.ask(
+        "\nElegí",
+        choices=["1", "2", "3", "4", "5"],
+        default="1",
+    )
+
+    model_info = WIZARD_PROVIDERS[provider]
+    model = model_info[0]
+    key_label = model_info[1]
+    needs_key = model_info[2]
+
+    # Step 2: API key
+    api_key = None
+    if needs_key and key_label:
+        api_key = Prompt.ask(f"\n{key_label}")
+
+    # Step 3: Language
+    lang = Prompt.ask(
+        "\nIdioma / Language",
+        choices=["es", "en", "pt"],
+        default="es",
+    )
+
+    # Step 4: Save
+    config = {
+        "language": lang,
+        "model": model,
+    }
+    if api_key:
+        config["api_key"] = api_key
+
+    config_path.write_text(yaml.dump(config, default_flow_style=False), encoding="utf-8")
+
+    # Summary
+    console.print()
+    console.print(Panel(
+        f"  Model:    [bold]{model}[/bold]\n"
+        f"  Language: [bold]{lang}[/bold]\n"
+        f"  Instance: [bold]{target_dir.name if target_dir.name != '.lumen' else 'default'}[/bold]\n"
+        f"  Config:   {config_path}",
+        title="[green]✓ Configuración guardada[/green]",
+        expand=False,
+        border_style="green",
+    ))
+
+    return config
+
+
+# ── command implementations ─────────────────────────────────────────────────
+
+
 @app.command()
 def run(
     port: int = typer.Option(3000, help="Dashboard port"),
     instance: str = typer.Option(None, "--instance", "-i", help="Named instance (isolated data dir)"),
     data_dir: str = typer.Option(None, "--data-dir", "-d", help="Custom data directory"),
+    no_wizard: bool = typer.Option(False, "--no-wizard", help="Skip wizard, error if no config (CI/CD)"),
 ):
     """Start Lumen — opens the dashboard in your browser.
 
-    If Lumen is not configured yet, the browser will show the setup wizard.
+    If Lumen is not configured yet, runs the CLI setup wizard automatically.
+    Use --no-wizard to skip wizard (useful for CI/CD).
     """
     from lumen.channels.web import app as web_app, configure, configure_access_mode
 
@@ -166,10 +262,19 @@ def run(
     configure_access_mode("run")
 
     config = _load_persisted_config(config_path)
+
+    # No config → run CLI wizard (unless --no-wizard)
+    if not _is_runtime_configured(config):
+        if no_wizard:
+            console.print("[red]No configuration found and --no-wizard is set.[/red]")
+            console.print("Create config.yaml manually or run without --no-wizard.")
+            raise typer.Exit(1)
+        config = _run_cli_wizard(lumen_dir=lumen_dir)
+
     runtime, config = _prepare_runtime_if_configured(config, lumen_dir=lumen_dir)
 
     if runtime is not None:
-        configure(runtime.brain, runtime.locale, runtime.config, awareness=runtime.awareness)
+        configure(runtime.brain, runtime.locale, runtime.config, awareness=runtime.awareness, lumen_dir=lumen_dir)
         use_port = port or config.get("port", 3000)
         lang = config.get("language", "en")
         mcp_count = len(runtime.brain.registry.list_by_kind(CapabilityKind.MCP))
@@ -180,6 +285,7 @@ def run(
                 f"  Dashboard:  [link]http://localhost:{use_port}[/link]\n"
                 f"  Model:      {config.get('model')}\n"
                 f"  Language:   {lang}\n"
+                f"  Instance:   {instance or 'default'}\n"
                 f"  Flows:      {len(runtime.brain.flows)}\n"
                 f"  MCP:        {mcp_count}",
                 title="Lumen",
@@ -213,6 +319,7 @@ def server(
     port: int = typer.Option(3000, help="Server bind port"),
     instance: str = typer.Option(None, "--instance", "-i", help="Named instance (isolated data dir)"),
     data_dir: str = typer.Option(None, "--data-dir", "-d", help="Custom data directory"),
+    no_wizard: bool = typer.Option(False, "--no-wizard", help="Skip wizard, error if no config (CI/CD)"),
 ):
     """Start Lumen in hosted/server mode with authenticated access."""
     from lumen.channels.web import (
@@ -229,9 +336,17 @@ def server(
     configure_access_mode("serve")
 
     config = _load_persisted_config(config_path)
+
+    # No config → run CLI wizard (unless --no-wizard)
+    if not _is_runtime_configured(config):
+        if no_wizard:
+            console.print("[red]No configuration found and --no-wizard is set.[/red]")
+            raise typer.Exit(1)
+        config = _run_cli_wizard(lumen_dir=lumen_dir)
+
     runtime, config = _prepare_runtime_if_configured(config, lumen_dir=lumen_dir)
     if runtime is not None:
-        configure(runtime.brain, runtime.locale, runtime.config, awareness=runtime.awareness)
+        configure(runtime.brain, runtime.locale, runtime.config, awareness=runtime.awareness, lumen_dir=lumen_dir)
 
     setup_token = ensure_server_bootstrap(host=host, port=port)
     current = _load_persisted_config(config_path)
@@ -264,9 +379,14 @@ def server(
 
 
 @app.command()
-def status():
+def status(
+    instance: str = typer.Option(None, "--instance", "-i", help="Named instance (isolated data dir)"),
+    data_dir: str = typer.Option(None, "--data-dir", "-d", help="Custom data directory"),
+):
     """Show Lumen's current configuration and health."""
-    config = _load_persisted_config()
+    lumen_dir = resolve_lumen_dir(instance=instance, data_dir=data_dir)
+    config_path = lumen_dir / "config.yaml"
+    config = _load_persisted_config(config_path)
     if not _is_runtime_configured(config):
         console.print("[red]Lumen is not installed.[/red]")
         console.print("Run [bold]lumen run[/bold] to start the setup wizard.")
@@ -279,7 +399,8 @@ def status():
             f"Language:  {config.get('language', 'en')}\n"
             f"Port:      {config.get('port', 3000)}\n"
             f"MCP:       {len(mcp.get('servers', {}))} servers\n"
-            f"Config:    {CONFIG_PATH}",
+            f"Instance:  {instance or 'default'}\n"
+            f"Config:    {config_path}",
             title="Lumen — Status",
             expand=False,
             border_style=BRAND,
@@ -545,7 +666,7 @@ def reload(
         console.print(f"[red]Reload failed: {e}[/red]")
         raise typer.Exit(1)
 
-    cap_count = len(brain.registry.list_all()) if brain.registry else 0
+    cap_count = len(brain.registry.all()) if brain.registry else 0
     console.print(f"[green]✓[/green] Runtime reloaded — {cap_count} capabilities active")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "enlumen"
-version = "0.3.0"
+version = "0.3.1"
 description = "Open-source AI agent engine. Modular. No limits."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_bugfixes_vps.py
+++ b/tests/test_bugfixes_vps.py
@@ -1,0 +1,229 @@
+"""Tests for VPS-reported bugs — Bugs #1 through #5.
+
+Bug #1: lumen status --instance
+Bug #2: reload crash list_all()
+Bug #3: API keys instance path mismatch
+Bug #4: web.py hardcoded LUMEN_DIR (root cause of #3)
+Bug #5: README serve vs server (verified manually)
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from lumen.channels import web
+from lumen.core.connectors import ConnectorRegistry
+from lumen.core.registry import Registry
+from lumen.core.session import SessionManager
+
+
+class BrainStub:
+    def __init__(self):
+        self.registry = Registry()
+        self.connectors = ConnectorRegistry()
+        self.flows = []
+        self.memory = MagicMock()
+        self.think_calls = []
+
+    async def think(self, message, session):
+        self.think_calls.append({"message": message, "session_id": session.session_id})
+        return {"message": f"Reply: {message}"}
+
+
+# ── Bug #4: web.py uses instance-aware LUMEN_DIR ────────────────────────────
+
+
+class Bug4WebInstanceIsolationTests(unittest.TestCase):
+    """Bug #4: configure() sets LUMEN_DIR and CONFIG_PATH from instance."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.original_lumen_dir = web.LUMEN_DIR
+        self.original_config_path = web.CONFIG_PATH
+        self.original_brain = web._brain
+        self.original_config = web._config
+        self.original_locale = web._locale
+        web._brain = None
+        web._config = {}
+        web._locale = {}
+        web.session_manager._sessions.clear()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+        web.LUMEN_DIR = self.original_lumen_dir
+        web.CONFIG_PATH = self.original_config_path
+        web._brain = self.original_brain
+        web._config = self.original_config
+        web._locale = self.original_locale
+        web.session_manager._sessions.clear()
+
+    def test_configure_sets_lumen_dir(self):
+        """configure() with lumen_dir updates global LUMEN_DIR."""
+        instance_dir = Path(self.temp_dir.name) / "instances" / "test"
+        instance_dir.mkdir(parents=True)
+        brain_stub = BrainStub()
+
+        web.configure(brain_stub, {}, {}, lumen_dir=instance_dir)
+
+        assert web.LUMEN_DIR == instance_dir
+        assert web.CONFIG_PATH == instance_dir / "config.yaml"
+
+    def test_configure_without_lumen_dir_keeps_default(self):
+        """configure() without lumen_dir keeps default ~/.lumen/."""
+        original_dir = web.LUMEN_DIR
+        brain_stub = BrainStub()
+
+        web.configure(brain_stub, {}, {})
+
+        assert web.LUMEN_DIR == original_dir
+
+    def test_api_reload_uses_instance_lumen_dir(self):
+        """POST /api/reload uses instance-aware LUMEN_DIR for sync."""
+        os.environ["LUMEN_API_KEY"] = "test-key"
+        instance_dir = Path(self.temp_dir.name) / "instances" / "test"
+        instance_dir.mkdir(parents=True)
+
+        web.configure(BrainStub(), {}, {"model": "test"}, lumen_dir=instance_dir)
+        client = TestClient(web.app)
+
+        assert web.LUMEN_DIR == instance_dir
+
+        with patch("lumen.channels.web.sync_runtime_modules", new_callable=AsyncMock), \
+             patch("lumen.channels.web.refresh_runtime_registry"), \
+             patch("lumen.channels.web.reload_runtime_personality_surface"):
+            response = client.post(
+                "/api/reload",
+                headers={"Authorization": "Bearer test-key"},
+            )
+            assert response.status_code == 200
+
+        os.environ.pop("LUMEN_API_KEY", None)
+
+
+# ── Bug #3: API keys with instance path ─────────────────────────────────────
+
+
+class Bug3APIKeyInstancePathTests(unittest.TestCase):
+    """Bug #3: API keys generated with --instance must validate in web.py."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.original_lumen_dir = web.LUMEN_DIR
+        self.original_config_path = web.CONFIG_PATH
+        self.original_brain = web._brain
+        self.original_config = web._config
+        self.original_locale = web._locale
+        web._brain = None
+        web._config = {}
+        web._locale = {}
+        web.session_manager._sessions.clear()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+        web.LUMEN_DIR = self.original_lumen_dir
+        web.CONFIG_PATH = self.original_config_path
+        web._brain = self.original_brain
+        web._config = self.original_config
+        web._locale = self.original_locale
+        web.session_manager._sessions.clear()
+        os.environ.pop("LUMEN_API_KEY", None)
+
+    def test_api_key_generated_for_instance_validates(self):
+        """Key generated with --instance validates via web auth."""
+        from lumen.core.api_keys import generate_api_key, verify_api_key
+
+        instance_dir = Path(self.temp_dir.name) / "instances" / "otto"
+        instance_dir.mkdir(parents=True)
+        keys_path = instance_dir / "api_keys.yaml"
+
+        # Generate key for instance
+        result = generate_api_key(label="otto-app", keys_path=keys_path)
+        generated_key = result["key"]
+
+        # Configure web with same instance dir
+        brain_stub = BrainStub()
+        web.configure(brain_stub, {}, {"model": "test"}, lumen_dir=instance_dir)
+        client = TestClient(web.app)
+
+        # Bearer auth should accept the instance key
+        response = client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": f"Bearer {generated_key}"},
+        )
+        assert response.status_code == 200
+
+    def test_api_key_from_different_instance_rejected(self):
+        """Key from instance A is rejected when web runs with instance B."""
+        from lumen.core.api_keys import generate_api_key
+
+        dir_a = Path(self.temp_dir.name) / "instances" / "a"
+        dir_a.mkdir(parents=True)
+        dir_b = Path(self.temp_dir.name) / "instances" / "b"
+        dir_b.mkdir(parents=True)
+
+        # Generate key for instance A
+        result = generate_api_key(label="app-a", keys_path=dir_a / "api_keys.yaml")
+        key_a = result["key"]
+
+        # Configure web with instance B
+        brain_stub = BrainStub()
+        web.configure(brain_stub, {}, {"model": "test"}, lumen_dir=dir_b)
+        client = TestClient(web.app)
+
+        # Key from A should be rejected on B
+        response = client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": f"Bearer {key_a}"},
+        )
+        assert response.status_code == 401
+
+
+# ── Bug #2: reload crash ────────────────────────────────────────────────────
+
+
+class Bug2ReloadCrashTests(unittest.TestCase):
+    """Bug #2: registry.list_all() should be registry.all()."""
+
+    def test_registry_has_all_method(self):
+        """Registry has .all() method, not .list_all()."""
+        reg = Registry()
+        assert hasattr(reg, "all"), "Registry should have .all() method"
+        assert not hasattr(reg, "list_all"), "Registry should NOT have .list_all()"
+
+
+# ── Bug #1: status --instance ────────────────────────────────────────────────
+
+
+class Bug1StatusInstanceTests(unittest.TestCase):
+    """Bug #1: lumen status accepts --instance flag."""
+
+    def test_status_command_accepts_instance(self):
+        """'lumen status --instance foo' does not error on unknown option."""
+        from typer.testing import CliRunner
+        from lumen.cli.main import app
+
+        runner = CliRunner()
+        # This should NOT fail with "No such option: --instance"
+        result = runner.invoke(app, ["status", "--instance", "nonexist"])
+        # It will fail because no config, but NOT because of unknown option
+        assert "No such option" not in result.output
+        assert result.exit_code != 0  # Expected: no config found
+
+    def test_status_command_accepts_data_dir(self):
+        """'lumen status --data-dir /tmp' does not error on unknown option."""
+        from typer.testing import CliRunner
+        from lumen.cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["status", "--data-dir", "/tmp/nonexist"])
+        assert "No such option" not in result.output
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -1,0 +1,131 @@
+"""Tests for CLI Twin Wizard — onboarding in terminal.
+
+Wizard triggers when no config.yaml exists in the instance dir.
+Saves config and returns it for the caller to bootstrap runtime.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+
+class CLIWizardTests(unittest.TestCase):
+    """Tests for _run_cli_wizard function."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.lumen_dir = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_wizard_function_exists(self):
+        """_run_cli_wizard is importable from cli.main."""
+        from lumen.cli.main import _run_cli_wizard
+        assert callable(_run_cli_wizard)
+
+    @patch("lumen.cli.main.Prompt.ask")
+    def test_wizard_saves_config_yaml(self, mock_ask):
+        """Wizard saves config.yaml with model, language, api_key."""
+        from lumen.cli.main import _run_cli_wizard
+
+        # Simulate: DeepSeek (1), API key, Spanish, port
+        mock_ask.side_effect = ["1", "sk-test-123", "es"]
+
+        _run_cli_wizard(lumen_dir=self.lumen_dir)
+
+        config_path = self.lumen_dir / "config.yaml"
+        assert config_path.exists(), "config.yaml should be created"
+
+        config = yaml.safe_load(config_path.read_text())
+        assert config["model"] == "deepseek/deepseek-chat"
+        assert config["language"] == "es"
+        assert config["api_key"] == "sk-test-123"
+
+    @patch("lumen.cli.main.Prompt.ask")
+    def test_wizard_ollama_no_api_key(self, mock_ask):
+        """Wizard with Ollama doesn't ask for API key."""
+        from lumen.cli.main import _run_cli_wizard
+
+        mock_ask.side_effect = ["4", "en"]
+
+        _run_cli_wizard(lumen_dir=self.lumen_dir)
+
+        config_path = self.lumen_dir / "config.yaml"
+        config = yaml.safe_load(config_path.read_text())
+        assert "api_key" not in config or config.get("api_key") is None
+        assert config["model"] == "ollama/llama3"
+
+    @patch("lumen.cli.main.Prompt.ask")
+    def test_wizard_returns_config(self, mock_ask):
+        """Wizard returns the config dict for caller to use."""
+        from lumen.cli.main import _run_cli_wizard
+
+        mock_ask.side_effect = ["1", "sk-test", "en"]
+
+        result = _run_cli_wizard(lumen_dir=self.lumen_dir)
+
+        assert isinstance(result, dict)
+        assert "model" in result
+        assert "language" in result
+
+    @patch("lumen.cli.main.Prompt.ask")
+    def test_wizard_creates_lumen_dir(self, mock_ask):
+        """Wizard creates lumen_dir if it doesn't exist."""
+        from lumen.cli.main import _run_cli_wizard
+
+        new_dir = self.lumen_dir / "instances" / "test"
+        mock_ask.side_effect = ["1", "sk-test", "es"]
+
+        _run_cli_wizard(lumen_dir=new_dir)
+
+        assert new_dir.exists()
+        assert (new_dir / "config.yaml").exists()
+
+    @patch("lumen.cli.main.Prompt.ask")
+    def test_wizard_openrouter_option(self, mock_ask):
+        """Wizard offers OpenRouter as a provider option."""
+        from lumen.cli.main import _run_cli_wizard
+
+        # Option 5 = OpenRouter (no API key needed, uses OAuth)
+        mock_ask.side_effect = ["5", "en"]
+
+        _run_cli_wizard(lumen_dir=self.lumen_dir)
+
+        config_path = self.lumen_dir / "config.yaml"
+        config = yaml.safe_load(config_path.read_text())
+        assert "openrouter" in config.get("model", "").lower()
+
+
+class CLIWizardIntegrationTests(unittest.TestCase):
+    """Tests for wizard integration with run/server commands."""
+
+    def test_run_command_calls_wizard_when_no_config(self):
+        """lumen run triggers wizard when no config.yaml exists."""
+        from typer.testing import CliRunner
+        from lumen.cli.main import app
+
+        runner = CliRunner()
+        # With a temp dir that has no config
+        with tempfile.TemporaryDirectory() as tmp:
+            # This will try to run wizard but Prompt.ask will fail in CI
+            # Just verify it doesn't crash with "No such option"
+            result = runner.invoke(app, ["run", "--data-dir", tmp])
+            # Should not error with unknown option
+            assert "No such option" not in (result.output or "")
+
+    def test_run_no_wizard_flag_exists(self):
+        """lumen run --no-wizard flag exists."""
+        from typer.testing import CliRunner
+        from lumen.cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["run", "--help"])
+        assert "no-wizard" in result.output.lower() or "no_wizard" in result.output.lower()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bugs fixed:
- #4 CRITICAL: web.py now uses instance-aware LUMEN_DIR/CONFIG_PATH via configure(lumen_dir=...) — fixes instance isolation in API
- #2 HIGH: reload crash — registry.list_all() -> registry.all()
- #3 HIGH: API keys with --instance now validate correctly (fixed by #4)
- #1 MEDIUM: status command accepts --instance and --data-dir flags
- #5 LOW: README corrected 'lumen serve' -> 'lumen server' (7 places)

New features:
- CLI Twin Wizard: _run_cli_wizard() runs onboarding in terminal when lumen run/server is called without config.yaml Supports DeepSeek, OpenAI, Anthropic, Ollama, OpenRouter
- --no-wizard flag for CI/CD (run and server commands)
- Module setup wizard by CLI (pending)