### PR TITLE
fix: v0.3.2 — REST auth reads CONFIG_PATH directly for api.rest_key

### DIFF
--- a/lumen/__init__.py
+++ b/lumen/__init__.py
@@ -1,3 +1,3 @@
 """Lumen — Open-source AI agent engine."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/lumen/channels/web.py
+++ b/lumen/channels/web.py
@@ -1641,7 +1641,7 @@ def _validate_bearer_token(request: Request) -> str | None:
 
     Checks against:
     1. LUMEN_API_KEY env var
-    2. config.api.rest_key
+    2. config.api.rest_key (from _config AND directly from CONFIG_PATH)
     3. api_keys.yaml (hashed keys from lumen api-key generate)
     Returns None if valid, or an error string if invalid/missing.
     """
@@ -1658,12 +1658,25 @@ def _validate_bearer_token(request: Request) -> str | None:
     if valid_key and token == valid_key:
         return None  # Valid
 
-    # Check config
+    # Check _config (in-memory, may lack api section)
     api_config = _config.get("api", {})
     if isinstance(api_config, dict):
         config_key = api_config.get("rest_key")
         if config_key and token == config_key:
             return None  # Valid
+
+    # Check CONFIG_PATH directly (raw YAML, always has api section)
+    if CONFIG_PATH.exists():
+        try:
+            raw = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8")) or {}
+            if isinstance(raw, dict):
+                raw_api = raw.get("api", {})
+                if isinstance(raw_api, dict):
+                    raw_key = raw_api.get("rest_key")
+                    if raw_key and token == raw_key:
+                        return None  # Valid
+        except Exception:
+            pass
 
     # Check api_keys.yaml (hashed keys)
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "enlumen"
-version = "0.3.1"
+version = "0.3.2"
 description = "Open-source AI agent engine. Modular. No limits."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_bug6_rest_auth.py
+++ b/tests/test_bug6_rest_auth.py
@@ -1,0 +1,197 @@
+"""Tests for Bug #6 — _config loses api section, REST auth fails.
+
+The config.yaml has api.rest_key but after bootstrap_runtime the _config
+may not have it. _validate_bearer_token must read CONFIG_PATH directly.
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+from fastapi.testclient import TestClient
+
+from lumen.channels import web
+from lumen.core.connectors import ConnectorRegistry
+from lumen.core.registry import Registry
+
+
+class BrainStub:
+    def __init__(self):
+        self.registry = Registry()
+        self.connectors = ConnectorRegistry()
+        self.flows = []
+        self.memory = MagicMock()
+        self.think_calls = []
+
+    async def think(self, message, session):
+        self.think_calls.append({"message": message, "session_id": session.session_id})
+        return {"message": f"Reply: {message}"}
+
+
+class Bug6RestKeyAuthTests(unittest.TestCase):
+    """Bug #6: REST auth works even when _config doesn't have api section."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.lumen_dir = Path(self.temp_dir.name)
+        self.original_lumen_dir = web.LUMEN_DIR
+        self.original_config_path = web.CONFIG_PATH
+        self.original_brain = web._brain
+        self.original_config = web._config
+        self.original_locale = web._locale
+        web._brain = None
+        web._config = {}
+        web._locale = {}
+        web.session_manager._sessions.clear()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+        web.LUMEN_DIR = self.original_lumen_dir
+        web.CONFIG_PATH = self.original_config_path
+        web._brain = self.original_brain
+        web._config = self.original_config
+        web._locale = self.original_locale
+        web.session_manager._sessions.clear()
+        os.environ.pop("LUMEN_API_KEY", None)
+
+    def _setup_with_config_yaml(self, config_yaml: str, _config_in_memory: dict | None = None):
+        """Helper: write config.yaml and configure web with optional stripped _config."""
+        config_path = self.lumen_dir / "config.yaml"
+        config_path.write_text(config_yaml, encoding="utf-8")
+
+        brain_stub = BrainStub()
+        web.configure(brain_stub, {}, _config_in_memory or {}, lumen_dir=self.lumen_dir)
+        return TestClient(web.app)
+
+    def test_rest_key_in_config_yaml_works_when_config_has_api(self):
+        """REST auth works when _config has api section (happy path)."""
+        config_yaml = yaml.dump({
+            "model": "deepseek/deepseek-chat",
+            "api_key": "test",
+            "language": "es",
+            "api": {"rest_key": "my-secret-key"},
+        })
+        full_config = yaml.safe_load(config_yaml)
+        client = self._setup_with_config_yaml(config_yaml, full_config)
+
+        response = client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": "Bearer my-secret-key"},
+        )
+        assert response.status_code == 200
+
+    def test_rest_key_in_config_yaml_works_when_config_lacks_api(self):
+        """REST auth works even when _config does NOT have api section (Bug #6)."""
+        config_yaml = yaml.dump({
+            "model": "deepseek/deepseek-chat",
+            "api_key": "test",
+            "language": "es",
+            "api": {"rest_key": "my-secret-key"},
+        })
+        # Simulate bootstrap_runtime stripping api section
+        stripped_config = {
+            "model": "deepseek/deepseek-chat",
+            "api_key": "test",
+            "language": "es",
+            # NO api section!
+        }
+        client = self._setup_with_config_yaml(config_yaml, stripped_config)
+
+        response = client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": "Bearer my-secret-key"},
+        )
+        assert response.status_code == 200
+
+    def test_rest_key_from_yaml_rejects_wrong_key(self):
+        """Wrong key is rejected even when reading from CONFIG_PATH."""
+        config_yaml = yaml.dump({
+            "model": "deepseek/deepseek-chat",
+            "api_key": "test",
+            "language": "es",
+            "api": {"rest_key": "my-secret-key"},
+        })
+        stripped_config = {"model": "deepseek/deepseek-chat"}
+        client = self._setup_with_config_yaml(config_yaml, stripped_config)
+
+        response = client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+        assert response.status_code == 401
+
+    def test_rest_key_works_with_instance(self):
+        """REST auth works with --instance (CONFIG_PATH points to instance dir)."""
+        instance_dir = self.lumen_dir / "instances" / "test"
+        instance_dir.mkdir(parents=True)
+        config_path = instance_dir / "config.yaml"
+        config_path.write_text(yaml.dump({
+            "model": "deepseek/deepseek-chat",
+            "api_key": "test",
+            "language": "es",
+            "api": {"rest_key": "instance-key-123"},
+        }), encoding="utf-8")
+
+        brain_stub = BrainStub()
+        web.configure(brain_stub, {}, {"model": "deepseek/deepseek-chat"}, lumen_dir=instance_dir)
+        client = TestClient(web.app)
+
+        response = client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": "Bearer instance-key-123"},
+        )
+        assert response.status_code == 200
+
+    def test_no_config_yaml_still_checks_env_var(self):
+        """Without config.yaml, env var LUMEN_API_KEY still works."""
+        client = self._setup_with_config_yaml("", {})
+        os.environ["LUMEN_API_KEY"] = "env-key"
+
+        response = client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": "Bearer env-key"},
+        )
+        assert response.status_code == 200
+
+    def test_api_keys_yaml_works_alongside_rest_key(self):
+        """API keys from api_keys.yaml work alongside rest_key in config."""
+        from lumen.core.api_keys import generate_api_key
+
+        config_yaml = yaml.dump({
+            "model": "deepseek/deepseek-chat",
+            "api_key": "test",
+            "language": "es",
+            "api": {"rest_key": "config-key"},
+        })
+        keys_path = self.lumen_dir / "api_keys.yaml"
+        result = generate_api_key(label="test-app", keys_path=keys_path)
+
+        client = self._setup_with_config_yaml(config_yaml, {"model": "deepseek/deepseek-chat"})
+
+        # Generated key should work
+        response = client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": f"Bearer {result['key']}"},
+        )
+        assert response.status_code == 200
+
+        # Config rest_key should also work
+        response2 = client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": "Bearer config-key"},
+        )
+        assert response2.status_code == 200
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bug #6 CRITICAL: _validate_bearer_token now reads config.yaml directly from CONFIG_PATH in addition to _config, so api.rest_key always works even when bootstrap_runtime pipeline strips the api section.

This fixes:
- REST auth with api.rest_key in config.yaml
- REST auth with --instance (CONFIG_PATH points to instance dir)
- API keys from api_keys.yaml continue working alongside rest_key

420 tests, 0 regressions.