### PR TITLE
fix(memory): recall natural-language queries with OR semantics and stopword filtering

### DIFF
--- a/lumen/core/memory.py
+++ b/lumen/core/memory.py
@@ -1,10 +1,35 @@
 """Persistent memory — SQLite with FTS5 full-text search."""
 
 import json
+import re
 import time
 from pathlib import Path
 
 import aiosqlite
+
+# Common Spanish/English words that carry no recall signal. Without this
+# filter a conversational query like "Te acordas de algo de lo que hablamos?"
+# requires every word to match (FTS5 implicit AND) and returns nothing.
+_STOPWORDS = frozenset(
+    """
+    a al algo ante antes aqui aquí asi así bien casi como cómo con contra cual
+    cuál cuando cuándo de del desde donde dónde dos el él ella ellas ellos en
+    entre era eres es esa ese eso esta está están estas este esto estos fue ha
+    han hasta hay la las le les lo los mas más me mi mis muy nada ni no nos
+    nosotros o os otra otro para pero poco por porque que qué quien quién se
+    ser si sí sin sobre solo sólo son soy su sus te ti tu tus un una unas unos
+    usted vos y ya yo
+    acordas acordás recordas recordás sabes sabés decime contame hablamos dijiste dije
+    a about after all also am an and any are as at be because been before but
+    by can could did do does doing down for from had has have he her here hers
+    him his how i if in into is it its just like me my no nor not now of off
+    on once only or other our out over own re s so some such t than that the
+    their them then there these they this those through to too under until up
+    very was we were what when where which while who whom why will with you
+    your yours
+    remember recall told said talked tell know
+    """.split()
+)
 
 
 class Memory:
@@ -120,10 +145,31 @@ class Memory:
         return cursor.lastrowid
 
     async def recall(self, query: str, limit: int = 5) -> list[dict]:
-        """Search memory using FTS5. Returns matching memories ranked by relevance."""
-        safe_query = " ".join(f'"{term}"' for term in query.split() if term.strip())
-        if not safe_query:
+        """Search memory using FTS5. Returns matching memories ranked by relevance.
+
+        Terms are OR-ed (any significant word may match) so natural-language
+        questions work; FTS5 rank still puts multi-term matches first.
+        """
+        raw_terms = [t for t in re.split(r"\W+", query, flags=re.UNICODE) if t]
+        if not raw_terms:
             return []
+
+        terms = [t for t in raw_terms if t.lower() not in _STOPWORDS]
+        if not terms:
+            # Query was pure conversational filler ("te acordas de lo que...")
+            # — recent memories are the best available context.
+            rows = await self._db.execute_fetchall(
+                """
+                SELECT id, content, category, metadata, created_at
+                FROM memories
+                ORDER BY created_at DESC
+                LIMIT ?
+                """,
+                (limit,),
+            )
+            return self._rows_to_memories(rows)
+
+        safe_query = " OR ".join(f'"{term}"' for term in terms)
 
         try:
             rows = await self._db.execute_fetchall(
@@ -139,17 +185,22 @@ class Memory:
             )
         except Exception:
             # Fallback to LIKE search if FTS fails
+            like_clauses = " OR ".join(["content LIKE ?"] * len(terms))
             rows = await self._db.execute_fetchall(
-                """
+                f"""
                 SELECT id, content, category, metadata, created_at
                 FROM memories
-                WHERE content LIKE ?
+                WHERE {like_clauses}
                 ORDER BY created_at DESC
                 LIMIT ?
                 """,
-                (f"%{query}%", limit),
+                (*[f"%{term}%" for term in terms], limit),
             )
 
+        return self._rows_to_memories(rows)
+
+    @staticmethod
+    def _rows_to_memories(rows) -> list[dict]:
         return [
             {
                 "id": row[0],

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -114,6 +114,51 @@ class TestFTS5SpecialChars:
         assert len(results) >= 1
 
 
+# ── Natural language queries (issue #20) ─────────────────────────────
+
+
+class TestRecallNaturalLanguage:
+    async def test_natural_phrase_matches_on_significant_terms(self, memory):
+        """A conversational question must not require ALL its words to match."""
+        await memory.remember("A Humber le gusta el mate amargo")
+        results = await memory.recall(
+            "Te acordas de algo de lo que hablamos sobre el mate?"
+        )
+        assert len(results) == 1
+        assert "mate" in results[0]["content"]
+
+    async def test_natural_phrase_in_spanish_with_accents(self, memory):
+        await memory.remember("Su hija María lo visita los domingos")
+        results = await memory.recall("¿Quién me visita los domingos?")
+        assert len(results) == 1
+
+    async def test_natural_phrase_in_english(self, memory):
+        await memory.remember("User prefers tea over coffee in the morning")
+        results = await memory.recall("Do you remember what I drink in the morning?")
+        assert len(results) == 1
+
+    async def test_stopword_only_query_returns_recent_memories(self, memory):
+        """If nothing significant remains after filtering, return recent memories."""
+        await memory.remember("primera memoria")
+        await memory.remember("segunda memoria")
+        await memory.remember("tercera memoria")
+        results = await memory.recall("te acordas de lo que", limit=2)
+        assert len(results) == 2
+        assert results[0]["content"] == "tercera memoria"
+
+    async def test_no_match_on_significant_terms_returns_empty(self, memory):
+        await memory.remember("the quick brown fox")
+        results = await memory.recall("contame sobre astronomía")
+        assert results == []
+
+    async def test_relevance_still_ranks_multi_term_matches_first(self, memory):
+        await memory.remember("python web framework")
+        await memory.remember("toma la pastilla verde a las 15:30")
+        results = await memory.recall("la pastilla verde")
+        assert len(results) >= 1
+        assert "pastilla" in results[0]["content"]
+
+
 # ── Fallback to LIKE when FTS5 fails ─────────────────────────────────
 
 


### PR DESCRIPTION
Closes #20

## Problema
`recall()` armaba la query FTS5 con todos los términos entre comillas separados por espacio → AND implícito. Cualquier pregunta conversacional ('Te acordas de algo de lo que hablamos?') devolvía 0 resultados aunque la DB tuviera memorias relevantes. Verificado en producción (Ambar): 72 memorias guardadas, el agente respondía 'no tengo nada guardado'.

## Fix
- Tokenización por `\W+` (sanea puntuación, null bytes, operadores FTS).
- Filtro de stopwords es/en (artículos, pronombres, muletillas conversacionales).
- Términos significativos unidos con `OR` — `ORDER BY rank` sigue priorizando matches multi-término.
- Query 100% filler ('te acordas de lo que...') → devuelve las N memorias más recientes en vez de lista vacía.
- Fallback LIKE ahora también es por término (antes usaba la frase literal completa).

## Tests
- 6 tests nuevos en `TestRecallNaturalLanguage` (escritos primero, reproducen el bug de producción).
- Suite completa: `test_memory.py` 43/43, `test_brain.py` + `test_cerebellum.py` 145/145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)