### PR TITLE
feat(brain): inject latest session summary and facts into think context

### DIFF
--- a/lumen/core/brain.py
+++ b/lumen/core/brain.py
@@ -656,13 +656,59 @@ class Brain:
             return "en"
         return None
 
+    @staticmethod
+    def _continuity_prefix(session: Session) -> str | None:
+        """Session-id prefix that groups all sessions of the same human.
+
+        Mirrors _scoped_session_id without the per-session raw id. Role-less
+        sessions (single-user instances) return None: every stored summary
+        belongs to the same person.
+        """
+        role = str(getattr(session, "role", "") or "").strip().lower()
+        workspace = str(getattr(session, "workspace", "") or "").strip() or "default"
+        team = str(getattr(session, "team", "") or "").strip() or "no-team"
+        email = str(getattr(session, "user_email", "") or "").strip().lower() or "anon"
+        if role == "admin":
+            return f"global:{workspace}:"
+        if role == "team_admin":
+            return f"team:{workspace}:{team}:"
+        if role:
+            return f"user:{workspace}:{team}:{email}:"
+        return None
+
+    async def _load_session_continuity(self, session: Session) -> dict:
+        """Latest session summary + durable facts for this user.
+
+        Distilled knowledge exists in the DB but recall() only surfaces it when
+        the current message happens to match — the agent must greet already
+        knowing who it is talking to (issue #21).
+        """
+        empty = {"summary": "", "facts": []}
+        if not self.memory:
+            return empty
+        try:
+            prefix = self._continuity_prefix(session)
+            summaries = await self.memory.list_session_summaries(
+                limit=1, session_prefix=prefix
+            )
+            facts = await self.memory.list_session_facts(
+                limit=10, session_prefix=prefix
+            )
+        except Exception:
+            return empty
+        return {
+            "summary": summaries[0]["summary"] if summaries else "",
+            "facts": [f["fact"] for f in facts],
+        }
+
     async def _prepare_think_context(self, message: str, session: Session):
         """Prepare context, messages, and tools for the LLM call.
 
         Returns (context, messages, tools) tuple.
         """
-        # 1. Recall relevant memories
+        # 1. Recall relevant memories + cross-session continuity
         memories = await self.memory.recall(message, limit=5)
+        continuity = await self._load_session_continuity(session)
 
         # 2. Build context — Consciousness + Personality + Body + Catalog + State
         context = {
@@ -680,6 +726,7 @@ class Brain:
             "filled_slots": session.slots,
             "pending_slots": session.get_pending_slots(),
             "memories": memories,
+            "continuity": continuity,
             "available_flows": self.flows,
         }
 
@@ -2125,6 +2172,15 @@ class Brain:
                     "If multiple pending setups are relevant, do not assume which one the user wants; ask them to choose."
                 )
             system_parts.extend(triggers)
+
+        # Cross-session continuity — who this user is, before any recall match
+        continuity = context.get("continuity") or {}
+        if continuity.get("summary") or continuity.get("facts"):
+            system_parts.append("\n## What I know from previous sessions")
+            if continuity.get("summary"):
+                system_parts.append(f"Last session: {continuity['summary']}")
+            for fact in continuity.get("facts", []):
+                system_parts.append(f"- {fact}")
 
         # Relevant memories
         if context["memories"]:

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -2597,3 +2597,119 @@ class TestPersistenceResilience:
         assert result["message"] == "Response!"
         # Session history should still be updated in RAM
         # (even though persistence failed)
+
+
+# ── session continuity (issue #21) ───────────────────────────────────
+
+
+class TestSessionContinuity:
+    """The agent must start a conversation knowing the user — latest session
+    summary and durable facts injected into context, not only recall()."""
+
+    def _continuity_brain(self, summaries=None, facts=None):
+        brain = _make_brain()
+        brain.memory.recall = AsyncMock(return_value=[])
+        brain.memory.list_session_summaries = AsyncMock(return_value=summaries or [])
+        brain.memory.list_session_facts = AsyncMock(return_value=facts or [])
+        return brain
+
+    @pytest.mark.asyncio
+    async def test_context_includes_latest_summary_and_facts(self):
+        brain = self._continuity_brain(
+            summaries=[{"session_id": "s1", "summary": "Hablamos de su pastilla verde",
+                        "fact_count": 1, "turn_count": 6, "created_at": 1.0}],
+            facts=[{"id": 1, "session_id": "s1", "fact": "Se llama Humber",
+                    "category": "identity", "importance": 0.9, "created_at": 1.0}],
+        )
+        context, _, _ = await brain._prepare_think_context("Hola", Session())
+
+        assert context["continuity"]["summary"] == "Hablamos de su pastilla verde"
+        assert context["continuity"]["facts"] == ["Se llama Humber"]
+
+    @pytest.mark.asyncio
+    async def test_context_continuity_empty_when_no_history(self):
+        brain = self._continuity_brain()
+        context, _, _ = await brain._prepare_think_context("Hola", Session())
+
+        assert context["continuity"] == {"summary": "", "facts": []}
+
+    @pytest.mark.asyncio
+    async def test_continuity_failure_does_not_break_context(self):
+        brain = self._continuity_brain()
+        brain.memory.list_session_summaries = AsyncMock(side_effect=Exception("DB locked"))
+        context, _, _ = await brain._prepare_think_context("Hola", Session())
+
+        assert context["continuity"] == {"summary": "", "facts": []}
+
+    def test_prompt_renders_continuity_section(self):
+        brain = _make_brain()
+        context = {
+            "consciousness": "I am Lumen",
+            "personality": "assistant",
+            "body": "capabilities",
+            "catalog": "",
+            "active_flow": None,
+            "filled_slots": {},
+            "pending_slots": [],
+            "memories": [],
+            "available_flows": [],
+            "continuity": {
+                "summary": "Hablamos de su pastilla verde",
+                "facts": ["Se llama Humber", "Le gusta el mate amargo"],
+            },
+        }
+        system_msg = brain._build_prompt(context, "Hola", Session())[0]["content"]
+
+        assert "previous sessions" in system_msg
+        assert "Hablamos de su pastilla verde" in system_msg
+        assert "Se llama Humber" in system_msg
+        assert "Le gusta el mate amargo" in system_msg
+
+    def test_prompt_omits_continuity_section_when_empty(self):
+        brain = _make_brain()
+        context = {
+            "consciousness": "I am Lumen",
+            "personality": "assistant",
+            "body": "capabilities",
+            "catalog": "",
+            "active_flow": None,
+            "filled_slots": {},
+            "pending_slots": [],
+            "memories": [],
+            "available_flows": [],
+            "continuity": {"summary": "", "facts": []},
+        }
+        system_msg = brain._build_prompt(context, "Hola", Session())[0]["content"]
+
+        assert "previous sessions" not in system_msg
+
+    def test_prompt_handles_missing_continuity_key(self):
+        """Older callers may build context without the key — must not crash."""
+        brain = _make_brain()
+        context = {
+            "consciousness": "I am Lumen",
+            "personality": "assistant",
+            "body": "capabilities",
+            "catalog": "",
+            "active_flow": None,
+            "filled_slots": {},
+            "pending_slots": [],
+            "memories": [],
+            "available_flows": [],
+        }
+        messages = brain._build_prompt(context, "Hola", Session())
+        assert messages[0]["role"] == "system"
+
+    @pytest.mark.asyncio
+    async def test_continuity_scopes_by_user_for_workspace_sessions(self):
+        brain = self._continuity_brain()
+        session = Session()
+        session.role = "user"
+        session.workspace = "acme"
+        session.team = "alpha"
+        session.user_email = "maria@example.com"
+
+        await brain._prepare_think_context("Hola", session)
+
+        kwargs = brain.memory.list_session_summaries.call_args.kwargs
+        assert kwargs.get("session_prefix") == "user:acme:alpha:maria@example.com:"


### PR DESCRIPTION
Closes #21

## Problema
El distiller guarda `session_summaries` y `session_facts`, pero `_prepare_think_context()` solo inyectaba `recall(message)` — el conocimiento destilado solo aparecía si el mensaje actual casualmente matcheaba. El agente saludaba cada día sin saber con quién hablaba (verificado en producción Ambar: 2 summaries + 13 facts en DB, y el agente dijo 'recién estamos empezando a charlar').

## Fix
- `_load_session_continuity()`: trae el último summary + hasta 10 facts del usuario, siempre, en cada turno.
- `_continuity_prefix()`: espeja `_scoped_session_id` sin el id crudo — en workspaces escopea por usuario (`user:{ws}:{team}:{email}:`), en instancias single-user (Ambar) toma todo el historial.
- Render en el system prompt como '## What I know from previous sessions', antes de las memorias por relevancia.
- Falla cerrado: cualquier error de DB → continuity vacía, el turno no se rompe.

## Tests
7 tests nuevos en `TestSessionContinuity` (TDD — escritos primero). Suites: brain 141/141, memory+cerebellum+rest_chat 63/63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)