### PR TITLE
fix(whatsapp): stop double-saving inbound messages to memory

### DIFF
--- a/lumen/catalog/modules/x-lumen-comunicacion-whatsapp/connector.py
+++ b/lumen/catalog/modules/x-lumen-comunicacion-whatsapp/connector.py
@@ -560,15 +560,10 @@ class WhatsAppRuntime:
                 + "\n"
             )
 
-        if (
-            self.context.memory is not None
-            and getattr(self.context.memory, "_db", None) is not None
-        ):
-            await self.context.memory.remember(
-                body,
-                category="whatsapp_message",
-                metadata={"chat_id": str(chat_id), "module": MODULE_NAME},
-            )
+        # Conversation persistence is owned by Brain.think (saved as
+        # conversation:{session}); saving here too duplicated every inbound
+        # message in memories and polluted FTS recall (issue #22). The
+        # inbox.jsonl archive above keeps the raw channel log.
 
     async def _invoke_inbound_hooks(
         self, chat_id: str, body: str, metadata: dict, inbound: dict

--- a/tests/test_whatsapp_ambar_hooks.py
+++ b/tests/test_whatsapp_ambar_hooks.py
@@ -229,3 +229,35 @@ class WhatsAppSendApiTests(unittest.TestCase):
         assert response.status_code == 200
         assert response.json()["message_id"] == "mid"
         runtime.send_message.assert_awaited_once()
+
+
+class WhatsAppMemoryDuplicationTests(unittest.TestCase):
+    """Issue #22: inbound messages were persisted twice — once here as
+    'whatsapp_message' and once by Brain.think as 'conversation:{session}'.
+    The brain owns conversation persistence; the connector must not save."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.runtime_dir = Path(self.temp_dir.name)
+        self.connector = load_connector()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_inbound_message_is_not_saved_to_memory_by_connector(self):
+        ctx = FakeContext(self.runtime_dir)
+        ctx.memory = MagicMock()
+        ctx.memory._db = object()
+        ctx.memory.remember = AsyncMock()
+        runtime = self.connector.WhatsAppRuntime(ctx)
+
+        async def run():
+            await runtime._handle_message(
+                {"chatId": "c1", "senderId": "s1", "body": "Hola! Muy bien", "id": "m1"}
+            )
+
+        asyncio.run(run())
+        ctx.memory.remember.assert_not_awaited()
+        # The jsonl inbox archive still captures the message
+        rows = (self.runtime_dir / "inbox.jsonl").read_text(encoding="utf-8").splitlines()
+        assert json.loads(rows[0])["text"] == "Hola! Muy bien"


### PR DESCRIPTION
Closes #22

## Problema
Cada mensaje entrante de WhatsApp se guardaba DOS veces en `memories`: el connector como `whatsapp_message` y `Brain.think()` como `conversation:{session}`. Verificado en producción (Ambar): ids 62/63, 65/66, 68/69 son pares idénticos con ~1.5s de diferencia y exactamente esas dos categorías.

## Fix
Se elimina el `remember()` del connector. La persistencia de conversación es responsabilidad del brain (con rol y sesión); el connector ya archiva el log crudo del canal en `inbox.jsonl`.

## Tests
- Test nuevo (TDD): el connector no debe llamar `memory.remember` y el archivo `inbox.jsonl` sigue capturando el mensaje.
- `test_whatsapp_ambar_hooks.py` 8/8, `test_memory.py` + `test_brain.py` 178/178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)