### PR TITLE
feat(scheduler): functional scheduler module — jobs that actually fire

### DIFF
--- a/lumen/catalog/modules/scheduler/SKILL.md
+++ b/lumen/catalog/modules/scheduler/SKILL.md
@@ -1,46 +1,39 @@
 ---
 name: scheduler
-description: "Schedule reminders and recurring tasks. Use task__create with due_date to save reminders."
+description: "Schedule reminders and recurring tasks that fire automatically. Use scheduler__create to save them."
 min_capability: tier-2
-provides: [task__create with due_date, task__list for pending reminders]
+provides: [scheduler__create, scheduler__list, scheduler__cancel]
 requires:
-  connectors: [task, memory]
+  connectors: [memory]
 ---
 # Scheduler
 
-You can now schedule reminders and recurring tasks for users.
+You can schedule reminders that are DELIVERED AUTOMATICALLY at the right time
+through the conversation channel. A background loop fires them — you do not
+need to do anything at delivery time.
 
 ## How to handle reminder requests
 
-When a user says things like:
+When the user says things like:
 - "Remind me to call Maria at 3pm"
 - "Every Monday, remind me to check reports"
 - "In 30 minutes, tell me to take a break"
 
 Do the following:
-1. Extract WHAT to remind (the action/task)
-2. Extract WHEN (specific time, relative time, or recurring pattern)
-3. Use task__create to save the reminder with due_date in the metadata
-4. Confirm to the user with the exact time and action
+1. Extract WHAT to remind (keep the user's words)
+2. Resolve WHEN to an absolute local date-time 'YYYY-MM-DD HH:MM'
+   (compute relative times like "in 30 minutes" yourself)
+3. Call scheduler__create with text + when (+ recurrence for recurring:
+   'daily' or 'weekly:mon'..'weekly:sun')
+4. Confirm back to the user with the exact date and time
 
-## Formatting times
+## Managing reminders
 
-- Always confirm the time back to the user in their timezone
-- For relative times ("in 30 minutes"), calculate the actual time
-- For recurring ("every Monday"), note the pattern in metadata
+- "What reminders do I have?" → scheduler__list
+- "Cancel the X reminder" → scheduler__list to find the job id, then scheduler__cancel
 
-## Examples
+## Rules
 
-User: "Remind me to call Maria at 3pm"
-→ task__create(description="Call Maria", due_date="today 15:00", priority="high")
-→ "Done! I'll remind you to call Maria at 3:00 PM."
-
-User: "Every Friday, remind me to submit the report"
-→ task__create(description="Submit weekly report", due_date="recurring:friday", priority="medium")
-→ "Noted! I'll remind you every Friday to submit the report."
-
-## Limitations
-
-Currently reminders are saved as tasks with due dates. Active time-based
-triggering (push notification at exact time) requires the heartbeat module.
-For now, users can ask "What are my pending reminders?" and Neo will list them.
+- NEVER claim a reminder is set without calling scheduler__create and getting
+  back a job id. If the call returns an error, tell the user honestly.
+- Always confirm times in the user's timezone.

--- a/lumen/catalog/modules/scheduler/connector.py
+++ b/lumen/catalog/modules/scheduler/connector.py
@@ -1,0 +1,368 @@
+"""Scheduler module — reminders and recurring tasks that actually fire.
+
+The LLM creates jobs with scheduler__create during conversation; a background
+loop checks due jobs every SWEEP_INTERVAL seconds and delivers them through
+the originating channel's message.send_* tool. Jobs persist in SQLite under
+the module runtime dir, so they survive restarts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+logger = logging.getLogger("lumen.module.scheduler")
+
+MODULE_NAME = "x-lumen-scheduler"
+SWEEP_INTERVAL_SECONDS = 30
+KNOWN_CHANNELS = ("whatsapp", "telegram", "discord", "email")
+WEEKDAYS = {"mon": 0, "tue": 1, "wed": 2, "thu": 3, "fri": 4, "sat": 5, "sun": 6}
+
+
+class SchedulerRuntime:
+    def __init__(self, context):
+        self.context = context
+        self.db_path = Path(context.ensure_runtime_dir()) / "scheduler.db"
+        self._db: sqlite3.Connection | None = None
+        self._loop_task: asyncio.Task | None = None
+        self._lock = asyncio.Lock()
+
+    # ── persistence ────────────────────────────────────────────────
+
+    async def init_store(self):
+        def _open():
+            # to_thread may use a different worker thread per call; access is
+            # serialized with self._lock, so cross-thread use is safe.
+            db = sqlite3.connect(str(self.db_path), check_same_thread=False)
+            db.row_factory = sqlite3.Row
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS scheduled_jobs (
+                    id TEXT PRIMARY KEY,
+                    text TEXT NOT NULL,
+                    due_at TEXT NOT NULL,
+                    recurrence TEXT DEFAULT '',
+                    channel TEXT NOT NULL,
+                    chat_id TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    created_at TEXT NOT NULL,
+                    fired_at TEXT,
+                    metadata TEXT DEFAULT '{}'
+                )
+                """
+            )
+            db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_jobs_status_due ON scheduled_jobs(status, due_at)"
+            )
+            db.commit()
+            return db
+
+        self._db = await asyncio.to_thread(_open)
+
+    async def close(self):
+        if self._loop_task:
+            self._loop_task.cancel()
+            try:
+                await self._loop_task
+            except asyncio.CancelledError:
+                pass
+            self._loop_task = None
+        if self._db:
+            await asyncio.to_thread(self._db.close)
+            self._db = None
+
+    def _tz(self):
+        locale = (self.context.config or {}).get("locale", {})
+        tz_name = locale.get("timezone") if isinstance(locale, dict) else None
+        if tz_name:
+            try:
+                return ZoneInfo(str(tz_name))
+            except ZoneInfoNotFoundError:
+                logger.warning("Invalid scheduler timezone %s; using system local", tz_name)
+        return datetime.now().astimezone().tzinfo
+
+    def _now(self) -> datetime:
+        return datetime.now(self._tz())
+
+    def _parse_when(self, when: str) -> datetime | None:
+        raw = str(when or "").strip().replace("T", " ")
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+            try:
+                parsed = datetime.strptime(raw, fmt)
+                return parsed.replace(tzinfo=self._tz())
+            except ValueError:
+                continue
+        try:
+            parsed = datetime.fromisoformat(str(when))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=self._tz())
+            return parsed
+        except ValueError:
+            return None
+
+    # ── job operations (also the LLM tool handlers) ────────────────
+
+    async def create_job(
+        self,
+        text: str = "",
+        when: str = "",
+        channel: str = "",
+        chat_id: str = "",
+        recurrence: str = "",
+        **_ignored,
+    ) -> dict:
+        text = str(text or "").strip()
+        if not text:
+            return {"error": "text_required"}
+        due = self._parse_when(when)
+        if due is None:
+            return {"error": "invalid_when", "hint": "Use 'YYYY-MM-DD HH:MM' in the user's local time."}
+        if due <= self._now():
+            return {"error": "when_in_past", "hint": "The reminder time must be in the future."}
+        channel = str(channel or "").strip().lower()
+        chat_id = str(chat_id or "").strip()
+        if not channel or not chat_id:
+            resolved = self._resolve_default_target()
+            channel = channel or resolved[0]
+            chat_id = chat_id or resolved[1]
+        if not channel or not chat_id:
+            return {
+                "error": "no_delivery_target",
+                "hint": "No channel/chat_id given and no default could be resolved.",
+            }
+        recurrence = str(recurrence or "").strip().lower()
+        if recurrence and not self._valid_recurrence(recurrence):
+            return {"error": "invalid_recurrence", "hint": "Use 'daily' or 'weekly:mon'..'weekly:sun'."}
+
+        job = {
+            "id": f"job-{secrets.token_hex(6)}",
+            "text": text,
+            "due_at": due.isoformat(),
+            "recurrence": recurrence,
+            "channel": channel,
+            "chat_id": chat_id,
+            "status": "pending",
+            "created_at": self._now().isoformat(),
+        }
+
+        def _insert():
+            self._db.execute(
+                "INSERT INTO scheduled_jobs (id, text, due_at, recurrence, channel, chat_id, status, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (job["id"], job["text"], job["due_at"], job["recurrence"],
+                 job["channel"], job["chat_id"], job["status"], job["created_at"]),
+            )
+            self._db.commit()
+
+        async with self._lock:
+            await asyncio.to_thread(_insert)
+        logger.info("Scheduler job created: %s at %s (%s)", job["id"], job["due_at"], recurrence or "once")
+        return job
+
+    async def list_jobs(self, **_ignored) -> list[dict]:
+        def _query():
+            rows = self._db.execute(
+                "SELECT id, text, due_at, recurrence, channel, chat_id, status, created_at "
+                "FROM scheduled_jobs WHERE status = 'pending' ORDER BY due_at ASC LIMIT 50"
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+        async with self._lock:
+            return await asyncio.to_thread(_query)
+
+    async def cancel_job(self, job_id: str = "", **_ignored) -> dict:
+        job_id = str(job_id or "").strip()
+        if not job_id:
+            return {"error": "job_id_required"}
+
+        def _cancel():
+            cursor = self._db.execute(
+                "UPDATE scheduled_jobs SET status = 'cancelled' WHERE id = ? AND status = 'pending'",
+                (job_id,),
+            )
+            self._db.commit()
+            return cursor.rowcount
+
+        async with self._lock:
+            updated = await asyncio.to_thread(_cancel)
+        if not updated:
+            return {"error": "not_found", "job_id": job_id}
+        return {"status": "cancelled", "job_id": job_id}
+
+    # ── firing ─────────────────────────────────────────────────────
+
+    async def fire_due_jobs(self) -> int:
+        """Deliver every pending job whose time has come. Returns fired count.
+
+        Delivery failures leave the job pending so the next sweep retries —
+        a reminder that never arrives is worse than one a minute late.
+        """
+        now_iso = self._now().isoformat()
+
+        def _due():
+            rows = self._db.execute(
+                "SELECT id, text, due_at, recurrence, channel, chat_id "
+                "FROM scheduled_jobs WHERE status = 'pending' AND due_at <= ? ORDER BY due_at ASC",
+                (now_iso,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+        async with self._lock:
+            due_jobs = await asyncio.to_thread(_due)
+
+        fired = 0
+        for job in due_jobs:
+            tool = f"message.send_{job['channel']}"
+            message = f"🔔 Recordatorio: {job['text']}"
+            try:
+                await self.context.connectors.execute_tool(
+                    tool, {"chat_id": job["chat_id"], "text": message}
+                )
+            except Exception as exc:
+                logger.warning("Scheduler delivery failed for %s via %s: %s", job["id"], tool, exc)
+                continue
+
+            next_due = self._next_occurrence(job)
+
+            def _mark(job=job, next_due=next_due):
+                if next_due is not None:
+                    self._db.execute(
+                        "UPDATE scheduled_jobs SET due_at = ?, fired_at = ? WHERE id = ?",
+                        (next_due.isoformat(), self._now().isoformat(), job["id"]),
+                    )
+                else:
+                    self._db.execute(
+                        "UPDATE scheduled_jobs SET status = 'done', fired_at = ? WHERE id = ?",
+                        (self._now().isoformat(), job["id"]),
+                    )
+                self._db.commit()
+
+            async with self._lock:
+                await asyncio.to_thread(_mark)
+            fired += 1
+            logger.info("Scheduler job fired: %s via %s", job["id"], tool)
+        return fired
+
+    @staticmethod
+    def _valid_recurrence(recurrence: str) -> bool:
+        if recurrence == "daily":
+            return True
+        if recurrence.startswith("weekly:"):
+            return recurrence.split(":", 1)[1] in WEEKDAYS
+        return False
+
+    def _next_occurrence(self, job: dict) -> datetime | None:
+        recurrence = str(job.get("recurrence") or "").strip().lower()
+        if not recurrence:
+            return None
+        base = self._parse_when(job["due_at"]) or self._now()
+        now = self._now()
+        if recurrence == "daily":
+            nxt = base + timedelta(days=1)
+            while nxt <= now:
+                nxt += timedelta(days=1)
+            return nxt
+        if recurrence.startswith("weekly:"):
+            nxt = base + timedelta(days=7)
+            while nxt <= now:
+                nxt += timedelta(days=7)
+            return nxt
+        return None
+
+    def _resolve_default_target(self) -> tuple[str, str]:
+        """Fall back to module settings, then to the most recent chat of any
+        active communication channel (single-user instances)."""
+        channel = str(self.context.resolve_setting("default_channel") or "").strip().lower()
+        chat_id = str(self.context.resolve_setting("default_chat_id") or "").strip()
+        if channel and chat_id:
+            return channel, chat_id
+        runtime_root = Path(self.context.runtime_dir).parent
+        for candidate in KNOWN_CHANNELS:
+            for module_dir in (f"x-lumen-comunicacion-{candidate}", candidate):
+                state_path = runtime_root / module_dir / "runtime.json"
+                if not state_path.exists():
+                    continue
+                try:
+                    state = json.loads(state_path.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    continue
+                last_chat = str(state.get("last_chat_id") or "").strip()
+                if last_chat:
+                    return channel or candidate, chat_id or last_chat
+        return channel, chat_id
+
+    # ── background loop ────────────────────────────────────────────
+
+    async def start(self):
+        self._loop_task = asyncio.create_task(self._sweep_loop())
+
+    async def _sweep_loop(self):
+        while True:
+            try:
+                await self.fire_due_jobs()
+            except Exception:
+                logger.exception("Scheduler sweep failed; retrying next interval")
+            await asyncio.sleep(SWEEP_INTERVAL_SECONDS)
+
+
+async def activate(context):
+    runtime = SchedulerRuntime(context)
+    await runtime.init_store()
+
+    context.register_tool(
+        "scheduler__create",
+        "Schedule a reminder for the user. The message is delivered automatically "
+        "at the given time through the conversation channel. Use for any request "
+        "like 'remind me to X at Y' or recurring reminders.",
+        {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string", "description": "What to remind, in the user's words."},
+                "when": {
+                    "type": "string",
+                    "description": "Local date-time 'YYYY-MM-DD HH:MM'. Resolve relative times ('in 2 hours', 'tomorrow 10am') to absolute before calling.",
+                },
+                "recurrence": {
+                    "type": "string",
+                    "description": "Optional: 'daily' or 'weekly:mon'..'weekly:sun' for recurring reminders.",
+                },
+                "channel": {"type": "string", "description": "Optional delivery channel (whatsapp, telegram...). Defaults to the active conversation channel."},
+                "chat_id": {"type": "string", "description": "Optional chat id. Defaults to the active conversation."},
+            },
+            "required": ["text", "when"],
+        },
+        runtime.create_job,
+        metadata={"kind": "module", "module": MODULE_NAME},
+    )
+    context.register_tool(
+        "scheduler__list",
+        "List the user's pending scheduled reminders.",
+        {"type": "object", "properties": {}},
+        runtime.list_jobs,
+        metadata={"kind": "module", "module": MODULE_NAME},
+    )
+    context.register_tool(
+        "scheduler__cancel",
+        "Cancel a scheduled reminder by its job id (see scheduler__list).",
+        {
+            "type": "object",
+            "properties": {"job_id": {"type": "string", "description": "Job id to cancel."}},
+            "required": ["job_id"],
+        },
+        runtime.cancel_job,
+        metadata={"kind": "module", "module": MODULE_NAME},
+    )
+
+    await runtime.start()
+    return runtime
+
+
+async def deactivate(context, runtime):
+    if runtime is not None:
+        await runtime.close()

--- a/lumen/modules/scheduler/SKILL.md
+++ b/lumen/modules/scheduler/SKILL.md
@@ -1,46 +1,39 @@
 ---
 name: scheduler
-description: "Schedule reminders and recurring tasks. Use task__create with due_date to save reminders."
+description: "Schedule reminders and recurring tasks that fire automatically. Use scheduler__create to save them."
 min_capability: tier-2
-provides: [task__create with due_date, task__list for pending reminders]
+provides: [scheduler__create, scheduler__list, scheduler__cancel]
 requires:
-  connectors: [task, memory]
+  connectors: [memory]
 ---
 # Scheduler
 
-You can now schedule reminders and recurring tasks for users.
+You can schedule reminders that are DELIVERED AUTOMATICALLY at the right time
+through the conversation channel. A background loop fires them — you do not
+need to do anything at delivery time.
 
 ## How to handle reminder requests
 
-When a user says things like:
+When the user says things like:
 - "Remind me to call Maria at 3pm"
 - "Every Monday, remind me to check reports"
 - "In 30 minutes, tell me to take a break"
 
 Do the following:
-1. Extract WHAT to remind (the action/task)
-2. Extract WHEN (specific time, relative time, or recurring pattern)
-3. Use task__create to save the reminder with due_date in the metadata
-4. Confirm to the user with the exact time and action
+1. Extract WHAT to remind (keep the user's words)
+2. Resolve WHEN to an absolute local date-time 'YYYY-MM-DD HH:MM'
+   (compute relative times like "in 30 minutes" yourself)
+3. Call scheduler__create with text + when (+ recurrence for recurring:
+   'daily' or 'weekly:mon'..'weekly:sun')
+4. Confirm back to the user with the exact date and time
 
-## Formatting times
+## Managing reminders
 
-- Always confirm the time back to the user in their timezone
-- For relative times ("in 30 minutes"), calculate the actual time
-- For recurring ("every Monday"), note the pattern in metadata
+- "What reminders do I have?" → scheduler__list
+- "Cancel the X reminder" → scheduler__list to find the job id, then scheduler__cancel
 
-## Examples
+## Rules
 
-User: "Remind me to call Maria at 3pm"
-→ task__create(description="Call Maria", due_date="today 15:00", priority="high")
-→ "Done! I'll remind you to call Maria at 3:00 PM."
-
-User: "Every Friday, remind me to submit the report"
-→ task__create(description="Submit weekly report", due_date="recurring:friday", priority="medium")
-→ "Noted! I'll remind you every Friday to submit the report."
-
-## Limitations
-
-Currently reminders are saved as tasks with due dates. Active time-based
-triggering (push notification at exact time) requires the heartbeat module.
-For now, users can ask "What are my pending reminders?" and Neo will list them.
+- NEVER claim a reminder is set without calling scheduler__create and getting
+  back a job id. If the call returns an error, tell the user honestly.
+- Always confirm times in the user's timezone.

--- a/lumen/modules/scheduler/connector.py
+++ b/lumen/modules/scheduler/connector.py
@@ -1,0 +1,368 @@
+"""Scheduler module — reminders and recurring tasks that actually fire.
+
+The LLM creates jobs with scheduler__create during conversation; a background
+loop checks due jobs every SWEEP_INTERVAL seconds and delivers them through
+the originating channel's message.send_* tool. Jobs persist in SQLite under
+the module runtime dir, so they survive restarts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+logger = logging.getLogger("lumen.module.scheduler")
+
+MODULE_NAME = "x-lumen-scheduler"
+SWEEP_INTERVAL_SECONDS = 30
+KNOWN_CHANNELS = ("whatsapp", "telegram", "discord", "email")
+WEEKDAYS = {"mon": 0, "tue": 1, "wed": 2, "thu": 3, "fri": 4, "sat": 5, "sun": 6}
+
+
+class SchedulerRuntime:
+    def __init__(self, context):
+        self.context = context
+        self.db_path = Path(context.ensure_runtime_dir()) / "scheduler.db"
+        self._db: sqlite3.Connection | None = None
+        self._loop_task: asyncio.Task | None = None
+        self._lock = asyncio.Lock()
+
+    # ── persistence ────────────────────────────────────────────────
+
+    async def init_store(self):
+        def _open():
+            # to_thread may use a different worker thread per call; access is
+            # serialized with self._lock, so cross-thread use is safe.
+            db = sqlite3.connect(str(self.db_path), check_same_thread=False)
+            db.row_factory = sqlite3.Row
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS scheduled_jobs (
+                    id TEXT PRIMARY KEY,
+                    text TEXT NOT NULL,
+                    due_at TEXT NOT NULL,
+                    recurrence TEXT DEFAULT '',
+                    channel TEXT NOT NULL,
+                    chat_id TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    created_at TEXT NOT NULL,
+                    fired_at TEXT,
+                    metadata TEXT DEFAULT '{}'
+                )
+                """
+            )
+            db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_jobs_status_due ON scheduled_jobs(status, due_at)"
+            )
+            db.commit()
+            return db
+
+        self._db = await asyncio.to_thread(_open)
+
+    async def close(self):
+        if self._loop_task:
+            self._loop_task.cancel()
+            try:
+                await self._loop_task
+            except asyncio.CancelledError:
+                pass
+            self._loop_task = None
+        if self._db:
+            await asyncio.to_thread(self._db.close)
+            self._db = None
+
+    def _tz(self):
+        locale = (self.context.config or {}).get("locale", {})
+        tz_name = locale.get("timezone") if isinstance(locale, dict) else None
+        if tz_name:
+            try:
+                return ZoneInfo(str(tz_name))
+            except ZoneInfoNotFoundError:
+                logger.warning("Invalid scheduler timezone %s; using system local", tz_name)
+        return datetime.now().astimezone().tzinfo
+
+    def _now(self) -> datetime:
+        return datetime.now(self._tz())
+
+    def _parse_when(self, when: str) -> datetime | None:
+        raw = str(when or "").strip().replace("T", " ")
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+            try:
+                parsed = datetime.strptime(raw, fmt)
+                return parsed.replace(tzinfo=self._tz())
+            except ValueError:
+                continue
+        try:
+            parsed = datetime.fromisoformat(str(when))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=self._tz())
+            return parsed
+        except ValueError:
+            return None
+
+    # ── job operations (also the LLM tool handlers) ────────────────
+
+    async def create_job(
+        self,
+        text: str = "",
+        when: str = "",
+        channel: str = "",
+        chat_id: str = "",
+        recurrence: str = "",
+        **_ignored,
+    ) -> dict:
+        text = str(text or "").strip()
+        if not text:
+            return {"error": "text_required"}
+        due = self._parse_when(when)
+        if due is None:
+            return {"error": "invalid_when", "hint": "Use 'YYYY-MM-DD HH:MM' in the user's local time."}
+        if due <= self._now():
+            return {"error": "when_in_past", "hint": "The reminder time must be in the future."}
+        channel = str(channel or "").strip().lower()
+        chat_id = str(chat_id or "").strip()
+        if not channel or not chat_id:
+            resolved = self._resolve_default_target()
+            channel = channel or resolved[0]
+            chat_id = chat_id or resolved[1]
+        if not channel or not chat_id:
+            return {
+                "error": "no_delivery_target",
+                "hint": "No channel/chat_id given and no default could be resolved.",
+            }
+        recurrence = str(recurrence or "").strip().lower()
+        if recurrence and not self._valid_recurrence(recurrence):
+            return {"error": "invalid_recurrence", "hint": "Use 'daily' or 'weekly:mon'..'weekly:sun'."}
+
+        job = {
+            "id": f"job-{secrets.token_hex(6)}",
+            "text": text,
+            "due_at": due.isoformat(),
+            "recurrence": recurrence,
+            "channel": channel,
+            "chat_id": chat_id,
+            "status": "pending",
+            "created_at": self._now().isoformat(),
+        }
+
+        def _insert():
+            self._db.execute(
+                "INSERT INTO scheduled_jobs (id, text, due_at, recurrence, channel, chat_id, status, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (job["id"], job["text"], job["due_at"], job["recurrence"],
+                 job["channel"], job["chat_id"], job["status"], job["created_at"]),
+            )
+            self._db.commit()
+
+        async with self._lock:
+            await asyncio.to_thread(_insert)
+        logger.info("Scheduler job created: %s at %s (%s)", job["id"], job["due_at"], recurrence or "once")
+        return job
+
+    async def list_jobs(self, **_ignored) -> list[dict]:
+        def _query():
+            rows = self._db.execute(
+                "SELECT id, text, due_at, recurrence, channel, chat_id, status, created_at "
+                "FROM scheduled_jobs WHERE status = 'pending' ORDER BY due_at ASC LIMIT 50"
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+        async with self._lock:
+            return await asyncio.to_thread(_query)
+
+    async def cancel_job(self, job_id: str = "", **_ignored) -> dict:
+        job_id = str(job_id or "").strip()
+        if not job_id:
+            return {"error": "job_id_required"}
+
+        def _cancel():
+            cursor = self._db.execute(
+                "UPDATE scheduled_jobs SET status = 'cancelled' WHERE id = ? AND status = 'pending'",
+                (job_id,),
+            )
+            self._db.commit()
+            return cursor.rowcount
+
+        async with self._lock:
+            updated = await asyncio.to_thread(_cancel)
+        if not updated:
+            return {"error": "not_found", "job_id": job_id}
+        return {"status": "cancelled", "job_id": job_id}
+
+    # ── firing ─────────────────────────────────────────────────────
+
+    async def fire_due_jobs(self) -> int:
+        """Deliver every pending job whose time has come. Returns fired count.
+
+        Delivery failures leave the job pending so the next sweep retries —
+        a reminder that never arrives is worse than one a minute late.
+        """
+        now_iso = self._now().isoformat()
+
+        def _due():
+            rows = self._db.execute(
+                "SELECT id, text, due_at, recurrence, channel, chat_id "
+                "FROM scheduled_jobs WHERE status = 'pending' AND due_at <= ? ORDER BY due_at ASC",
+                (now_iso,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+        async with self._lock:
+            due_jobs = await asyncio.to_thread(_due)
+
+        fired = 0
+        for job in due_jobs:
+            tool = f"message.send_{job['channel']}"
+            message = f"🔔 Recordatorio: {job['text']}"
+            try:
+                await self.context.connectors.execute_tool(
+                    tool, {"chat_id": job["chat_id"], "text": message}
+                )
+            except Exception as exc:
+                logger.warning("Scheduler delivery failed for %s via %s: %s", job["id"], tool, exc)
+                continue
+
+            next_due = self._next_occurrence(job)
+
+            def _mark(job=job, next_due=next_due):
+                if next_due is not None:
+                    self._db.execute(
+                        "UPDATE scheduled_jobs SET due_at = ?, fired_at = ? WHERE id = ?",
+                        (next_due.isoformat(), self._now().isoformat(), job["id"]),
+                    )
+                else:
+                    self._db.execute(
+                        "UPDATE scheduled_jobs SET status = 'done', fired_at = ? WHERE id = ?",
+                        (self._now().isoformat(), job["id"]),
+                    )
+                self._db.commit()
+
+            async with self._lock:
+                await asyncio.to_thread(_mark)
+            fired += 1
+            logger.info("Scheduler job fired: %s via %s", job["id"], tool)
+        return fired
+
+    @staticmethod
+    def _valid_recurrence(recurrence: str) -> bool:
+        if recurrence == "daily":
+            return True
+        if recurrence.startswith("weekly:"):
+            return recurrence.split(":", 1)[1] in WEEKDAYS
+        return False
+
+    def _next_occurrence(self, job: dict) -> datetime | None:
+        recurrence = str(job.get("recurrence") or "").strip().lower()
+        if not recurrence:
+            return None
+        base = self._parse_when(job["due_at"]) or self._now()
+        now = self._now()
+        if recurrence == "daily":
+            nxt = base + timedelta(days=1)
+            while nxt <= now:
+                nxt += timedelta(days=1)
+            return nxt
+        if recurrence.startswith("weekly:"):
+            nxt = base + timedelta(days=7)
+            while nxt <= now:
+                nxt += timedelta(days=7)
+            return nxt
+        return None
+
+    def _resolve_default_target(self) -> tuple[str, str]:
+        """Fall back to module settings, then to the most recent chat of any
+        active communication channel (single-user instances)."""
+        channel = str(self.context.resolve_setting("default_channel") or "").strip().lower()
+        chat_id = str(self.context.resolve_setting("default_chat_id") or "").strip()
+        if channel and chat_id:
+            return channel, chat_id
+        runtime_root = Path(self.context.runtime_dir).parent
+        for candidate in KNOWN_CHANNELS:
+            for module_dir in (f"x-lumen-comunicacion-{candidate}", candidate):
+                state_path = runtime_root / module_dir / "runtime.json"
+                if not state_path.exists():
+                    continue
+                try:
+                    state = json.loads(state_path.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    continue
+                last_chat = str(state.get("last_chat_id") or "").strip()
+                if last_chat:
+                    return channel or candidate, chat_id or last_chat
+        return channel, chat_id
+
+    # ── background loop ────────────────────────────────────────────
+
+    async def start(self):
+        self._loop_task = asyncio.create_task(self._sweep_loop())
+
+    async def _sweep_loop(self):
+        while True:
+            try:
+                await self.fire_due_jobs()
+            except Exception:
+                logger.exception("Scheduler sweep failed; retrying next interval")
+            await asyncio.sleep(SWEEP_INTERVAL_SECONDS)
+
+
+async def activate(context):
+    runtime = SchedulerRuntime(context)
+    await runtime.init_store()
+
+    context.register_tool(
+        "scheduler__create",
+        "Schedule a reminder for the user. The message is delivered automatically "
+        "at the given time through the conversation channel. Use for any request "
+        "like 'remind me to X at Y' or recurring reminders.",
+        {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string", "description": "What to remind, in the user's words."},
+                "when": {
+                    "type": "string",
+                    "description": "Local date-time 'YYYY-MM-DD HH:MM'. Resolve relative times ('in 2 hours', 'tomorrow 10am') to absolute before calling.",
+                },
+                "recurrence": {
+                    "type": "string",
+                    "description": "Optional: 'daily' or 'weekly:mon'..'weekly:sun' for recurring reminders.",
+                },
+                "channel": {"type": "string", "description": "Optional delivery channel (whatsapp, telegram...). Defaults to the active conversation channel."},
+                "chat_id": {"type": "string", "description": "Optional chat id. Defaults to the active conversation."},
+            },
+            "required": ["text", "when"],
+        },
+        runtime.create_job,
+        metadata={"kind": "module", "module": MODULE_NAME},
+    )
+    context.register_tool(
+        "scheduler__list",
+        "List the user's pending scheduled reminders.",
+        {"type": "object", "properties": {}},
+        runtime.list_jobs,
+        metadata={"kind": "module", "module": MODULE_NAME},
+    )
+    context.register_tool(
+        "scheduler__cancel",
+        "Cancel a scheduled reminder by its job id (see scheduler__list).",
+        {
+            "type": "object",
+            "properties": {"job_id": {"type": "string", "description": "Job id to cancel."}},
+            "required": ["job_id"],
+        },
+        runtime.cancel_job,
+        metadata={"kind": "module", "module": MODULE_NAME},
+    )
+
+    await runtime.start()
+    return runtime
+
+
+async def deactivate(context, runtime):
+    if runtime is not None:
+        await runtime.close()

--- a/tests/test_scheduler_module.py
+++ b/tests/test_scheduler_module.py
@@ -1,0 +1,248 @@
+"""Tests for the functional scheduler module (issue #29).
+
+The scheduler must actually FIRE reminders: persist jobs, check due times,
+deliver through the originating channel tool, and survive restarts.
+"""
+
+import asyncio
+import importlib.util
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+CONNECTOR_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "lumen"
+    / "catalog"
+    / "modules"
+    / "scheduler"
+    / "connector.py"
+)
+
+
+def load_connector():
+    spec = importlib.util.spec_from_file_location("scheduler_connector_test", CONNECTOR_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeConnectors:
+    def __init__(self):
+        self.registered = {}
+        self.executed = []
+        self.known_tools = {"message.send_whatsapp"}
+
+    def register_tool(self, name, description, parameters, handler, metadata=None):
+        self.registered[name] = {"handler": handler, "parameters": parameters}
+
+    def unregister_tool(self, name):
+        self.registered.pop(name, None)
+
+    def _resolve_tool_name(self, name):
+        return name
+
+    def has_tool(self, name):
+        return name in self.known_tools
+
+    async def execute_tool(self, name, params=None):
+        if name not in self.known_tools:
+            raise ValueError(f"Unknown tool: {name}")
+        self.executed.append({"tool": name, "params": params})
+        return {"ok": True}
+
+
+class FakeContext:
+    def __init__(self, runtime_dir: Path, settings: dict | None = None):
+        self.name = "scheduler"
+        self.runtime_dir = runtime_dir
+        self.module_dir = runtime_dir
+        self.manifest = {}
+        self.config = {"locale": {"timezone": "America/Argentina/Buenos_Aires"}}
+        self.connectors = FakeConnectors()
+        self.settings = settings or {}
+        self.registered_tools = []
+
+    def ensure_runtime_dir(self):
+        self.runtime_dir.mkdir(parents=True, exist_ok=True)
+        return self.runtime_dir
+
+    def resolve_setting(self, key, env_name=None):
+        return self.settings.get(key)
+
+    def register_tool(self, name, description, parameters, handler, metadata=None):
+        self.connectors.register_tool(name, description, parameters, handler, metadata)
+        self.registered_tools.append(name)
+
+    def read_runtime_state(self):
+        return {}
+
+    def write_runtime_state(self, payload):
+        pass
+
+
+class SchedulerModuleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.runtime_dir = Path(self.temp_dir.name)
+        self.connector = load_connector()
+        self.ctx = FakeContext(self.runtime_dir)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _runtime(self):
+        return self.connector.SchedulerRuntime(self.ctx)
+
+    def test_activate_registers_tools(self):
+        async def run():
+            runtime = await self.connector.activate(self.ctx)
+            await self.connector.deactivate(self.ctx, runtime)
+
+        asyncio.run(run())
+        for tool in ("scheduler__create", "scheduler__list", "scheduler__cancel"):
+            assert tool in self.ctx.connectors.registered, tool
+
+    def test_create_and_list_job(self):
+        async def run():
+            runtime = self._runtime()
+            await runtime.init_store()
+            created = await runtime.create_job(
+                text="llamar a Maria",
+                when=(datetime.now() + timedelta(hours=2)).strftime("%Y-%m-%d %H:%M"),
+                channel="whatsapp",
+                chat_id="549111234",
+            )
+            assert created["id"]
+            jobs = await runtime.list_jobs()
+            assert len(jobs) == 1
+            assert jobs[0]["text"] == "llamar a Maria"
+            assert jobs[0]["status"] == "pending"
+            await runtime.close()
+
+        asyncio.run(run())
+
+    def test_create_rejects_past_time(self):
+        async def run():
+            runtime = self._runtime()
+            await runtime.init_store()
+            result = await runtime.create_job(
+                text="x",
+                when=(datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M"),
+                channel="whatsapp",
+                chat_id="1",
+            )
+            assert result.get("error")
+            await runtime.close()
+
+        asyncio.run(run())
+
+    def test_cancel_job(self):
+        async def run():
+            runtime = self._runtime()
+            await runtime.init_store()
+            created = await runtime.create_job(
+                text="cita medica",
+                when=(datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d %H:%M"),
+                channel="whatsapp",
+                chat_id="1",
+            )
+            result = await runtime.cancel_job(job_id=created["id"])
+            assert result["status"] == "cancelled"
+            jobs = await runtime.list_jobs()
+            assert jobs == []
+            await runtime.close()
+
+        asyncio.run(run())
+
+    def test_due_job_fires_through_channel_tool(self):
+        async def run():
+            runtime = self._runtime()
+            await runtime.init_store()
+            await runtime.create_job(
+                text="tomar agua",
+                when=(datetime.now() + timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S"),
+                channel="whatsapp",
+                chat_id="549111234",
+            )
+            await asyncio.sleep(1.2)
+            fired = await runtime.fire_due_jobs()
+            assert fired == 1
+            sent = self.ctx.connectors.executed
+            assert sent[0]["tool"] == "message.send_whatsapp"
+            assert "tomar agua" in sent[0]["params"]["text"]
+            assert sent[0]["params"]["chat_id"] == "549111234"
+            jobs = await runtime.list_jobs()
+            assert jobs == []  # done jobs are not pending
+            await runtime.close()
+
+        asyncio.run(run())
+
+    def test_recurring_job_reschedules_after_fire(self):
+        async def run():
+            runtime = self._runtime()
+            await runtime.init_store()
+            await runtime.create_job(
+                text="pastilla",
+                when=(datetime.now() + timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S"),
+                channel="whatsapp",
+                chat_id="1",
+                recurrence="daily",
+            )
+            await asyncio.sleep(1.2)
+            fired = await runtime.fire_due_jobs()
+            assert fired == 1
+            jobs = await runtime.list_jobs()
+            assert len(jobs) == 1  # rescheduled for tomorrow
+            next_due = datetime.fromisoformat(jobs[0]["due_at"])
+            assert next_due > datetime.now(next_due.tzinfo) + timedelta(hours=20)
+            await runtime.close()
+
+        asyncio.run(run())
+
+    def test_jobs_survive_restart(self):
+        async def run():
+            runtime = self._runtime()
+            await runtime.init_store()
+            await runtime.create_job(
+                text="persistente",
+                when=(datetime.now() + timedelta(days=2)).strftime("%Y-%m-%d %H:%M"),
+                channel="whatsapp",
+                chat_id="1",
+            )
+            await runtime.close()
+
+            # New runtime over the same runtime_dir = container restart
+            runtime2 = self._runtime()
+            await runtime2.init_store()
+            jobs = await runtime2.list_jobs()
+            assert len(jobs) == 1
+            assert jobs[0]["text"] == "persistente"
+            await runtime2.close()
+
+        asyncio.run(run())
+
+    def test_fire_failure_keeps_job_pending(self):
+        async def run():
+            runtime = self._runtime()
+            await runtime.init_store()
+            await runtime.create_job(
+                text="canal roto",
+                when=(datetime.now() + timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S"),
+                channel="telegram",  # not in known_tools → delivery fails
+                chat_id="1",
+            )
+            await asyncio.sleep(1.2)
+            fired = await runtime.fire_due_jobs()
+            assert fired == 0
+            jobs = await runtime.list_jobs()
+            assert len(jobs) == 1  # still pending, retried next sweep
+            await runtime.close()
+
+        asyncio.run(run())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #29

- SchedulerRuntime: SQLite persistence in module runtime dir, survives restarts
- tools scheduler__create/list/cancel registered for the LLM
- background sweep every 30s delivers due jobs via the originating channel's
  message.send_* tool; failed deliveries stay pending and retry
- recurrence: daily and weekly:dow
- delivery target fallback: module settings, then last active chat of any
  communication channel (single-user instances)
- SKILL.md rewritten: never claim a reminder is set without a job id
