### PR TITLE
fix(policy): classify scheduler tools — unknown-tool default blocked every reminder

### DIFF
--- a/lumen/core/tool_policy.py
+++ b/lumen/core/tool_policy.py
@@ -61,6 +61,11 @@ DEFAULT_TOOL_RISK: dict[str, dict[str, str]] = {
     "terminal": {
         "execute": ToolRisk.PRIVILEGED.value,
     },
+    "scheduler": {
+        "create": ToolRisk.MUTATING.value,
+        "list": ToolRisk.READ_ONLY.value,
+        "cancel": ToolRisk.MUTATING.value,
+    },
     "neo": {
         "read_skill": ToolRisk.READ_ONLY.value,
         "search_modules": ToolRisk.READ_ONLY.value,

--- a/tests/test_tool_policy.py
+++ b/tests/test_tool_policy.py
@@ -184,3 +184,38 @@ class TestRecordAction(unittest.TestCase):
         policy = ToolPolicy()
         policy.load_defaults()
         policy.record_action("task", "delete", approved=True)
+
+
+class TestSchedulerToolRisk:
+    """Scheduler tools must not fall into the unknown→privileged default:
+    that forces a human confirmation that REST/WhatsApp flows cannot give,
+    so every reminder request dies in a 60s timeout."""
+
+    def _policy(self):
+        from lumen.core.tool_policy import ToolPolicy
+        policy = ToolPolicy()
+        policy.load_defaults()
+        return policy
+
+    def test_scheduler_create_is_mutating_no_confirmation(self):
+        policy = self._policy()
+        entry = policy.get_policy("scheduler", "create")
+        assert entry.risk == "mutating"
+        assert policy.requires_confirmation(entry) is False
+
+    def test_scheduler_list_is_read_only(self):
+        policy = self._policy()
+        entry = policy.get_policy("scheduler", "list")
+        assert entry.risk == "read_only"
+        assert policy.requires_confirmation(entry) is False
+
+    def test_scheduler_cancel_is_mutating_no_confirmation(self):
+        policy = self._policy()
+        entry = policy.get_policy("scheduler", "cancel")
+        assert entry.risk == "mutating"
+        assert policy.requires_confirmation(entry) is False
+
+    def test_scheduler_tool_names_resolve_directly(self):
+        policy = self._policy()
+        entry = policy.get_policy("scheduler__create")
+        assert entry.risk == "mutating"


### PR DESCRIPTION
scheduler__create/cancel are mutating (no confirmation), scheduler__list is
read_only. Without this, the unknown→privileged default demanded a human
confirmation that REST/WhatsApp flows cannot provide, so every reminder
request died in a 60s confirmation timeout.
