### PR TITLE
feat(brain): inject current local date/time into the system prompt

### DIFF
--- a/lumen/core/brain.py
+++ b/lumen/core/brain.py
@@ -1978,6 +1978,35 @@ class Brain:
             logger.warning(f"Failed to load lessons: {e}")
             self._cached_lessons_text = ""
 
+    def _current_datetime_line(self) -> str:
+        """Current local date/time for the system prompt.
+
+        The model cannot infer the clock: reminders, greetings and any
+        time-relative reasoning produce wrong answers without this.
+        """
+        from datetime import datetime
+
+        tz = None
+        tz_name = ""
+        locale = self.config.get("locale") if isinstance(self.config, dict) else None
+        if isinstance(locale, dict):
+            tz_name = str(locale.get("timezone") or "").strip()
+        if tz_name:
+            try:
+                from zoneinfo import ZoneInfo
+
+                tz = ZoneInfo(tz_name)
+            except Exception:
+                tz = None
+        now = datetime.now(tz) if tz else datetime.now().astimezone()
+        label = tz_name or "system local time"
+        return (
+            "## Current date and time\n"
+            f"{now.strftime('%A %Y-%m-%d %H:%M')} ({label}). "
+            "Use this as the ONLY source for the current time when reasoning "
+            "about schedules, reminders or time of day."
+        )
+
     def _build_prompt(
         self, context: dict, message: str, session: Session, tools: list[dict] | None = None
     ) -> list[dict]:
@@ -2003,6 +2032,8 @@ class Brain:
             self._language_directive(message=message, session=session),
             "Treat the configured language as the default UI locale, but follow the user's actual conversational language when it is obvious.",
             "Even if other sections below are written in English, you MUST answer in the language above. Translate on the fly.",
+            "",
+            self._current_datetime_line(),
             "",
         ]
 

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -2713,3 +2713,48 @@ class TestSessionContinuity:
 
         kwargs = brain.memory.list_session_summaries.call_args.kwargs
         assert kwargs.get("session_prefix") == "user:acme:alpha:maria@example.com:"
+
+
+# ── current date/time awareness ──────────────────────────────────────
+
+
+class TestCurrentDateTimeInPrompt:
+    """The agent must know the current local date and time: scheduling
+    reminders and any time-relative conversation depend on it."""
+
+    def _context(self):
+        return {
+            "consciousness": "I am Lumen",
+            "personality": "assistant",
+            "body": "capabilities",
+            "catalog": "",
+            "active_flow": None,
+            "filled_slots": {},
+            "pending_slots": [],
+            "memories": [],
+            "available_flows": [],
+        }
+
+    def test_prompt_includes_current_datetime(self):
+        from datetime import datetime
+        brain = _make_brain(config={"locale": {"timezone": "America/Argentina/Buenos_Aires"}})
+        system_msg = brain._build_prompt(self._context(), "hola", Session())[0]["content"]
+
+        assert "Current date and time" in system_msg
+        try:
+            from zoneinfo import ZoneInfo
+            now = datetime.now(ZoneInfo("America/Argentina/Buenos_Aires"))
+        except Exception:
+            # No tzdata on this platform — code falls back to system local
+            now = datetime.now().astimezone()
+        assert now.strftime("%Y-%m-%d") in system_msg
+
+    def test_prompt_datetime_falls_back_without_locale(self):
+        brain = _make_brain()
+        system_msg = brain._build_prompt(self._context(), "hola", Session())[0]["content"]
+        assert "Current date and time" in system_msg
+
+    def test_prompt_datetime_survives_bad_timezone(self):
+        brain = _make_brain(config={"locale": {"timezone": "Not/AZone"}})
+        system_msg = brain._build_prompt(self._context(), "hola", Session())[0]["content"]
+        assert "Current date and time" in system_msg


### PR DESCRIPTION
The model cannot infer the clock: reminders (scheduler), greetings and any
time-relative reasoning produced wrong answers. Uses config locale.timezone,
falls back to system local time.
